### PR TITLE
Add dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,12 +21,35 @@
         if (theme === "dark") {
             document.documentElement.setAttribute('data-theme', 'dark');
         }
+
+        function onLoad() {
+            console.log("theme", theme);
+            if (!theme || theme === "light")
+                document.getElementById("dark-mode-toggle").checked = true;
+            else {
+                document.getElementById("dark-mode-toggle").checked = false;
+            }
+        }
     </script>
+    <script src="https://code.iconify.design/1/1.0.4/iconify.min.js"></script>
 </head>
 
 <body>
     <div class="navbar">
-        <button id="theme-toggle" onclick="toggleDarkMode()"></button>
+        <div class="navbar-dark-mode-toggle">
+            <label>
+                <input class='toggle-checkbox' type='checkbox' onclick="toggleDarkMode()" id="dark-mode-toggle"></input>
+                <div class='toggle-slot'>
+                  <div class='sun-icon-wrapper'>
+                    <div class="iconify sun-icon" data-icon="feather-sun" data-inline="false"></div>
+                  </div>
+                  <div class='toggle-button'></div>
+                  <div class='moon-icon-wrapper'>
+                    <div class="iconify moon-icon" data-icon="feather-moon" data-inline="false"></div>
+                  </div>
+                </div>
+              </label>
+        </div>
         <div class="navbar-logo">
             <h2>Time It</h2>
         </div>
@@ -161,17 +184,17 @@
     const userPrefers = getComputedStyle(document.documentElement).getPropertyValue('content');
 
     if (theme === "dark") {
-        document.getElementById("theme-toggle").innerHTML = "Light Mode";
+        document.getElementById("dark-mode-toggle").checked = false;
     } else if (theme === "light") {
-        document.getElementById("theme-toggle").innerHTML = "Dark Mode";
+        document.getElementById("dark-mode-toggle").checked = true;
     } else if  (userPrefers === "dark") {
         document.documentElement.setAttribute('data-theme', 'dark');
         window.localStorage.setItem('theme', 'dark');
-        document.getElementById("theme-toggle").innerHTML = "Light Mode";
+        document.getElementById("dark-mode-toggle").checked = false;
     } else {
         document.documentElement.setAttribute('data-theme', 'light');
         window.localStorage.setItem('theme', 'light');
-        document.getElementById("theme-toggle").innerHTML = "Dark Mode";
+        document.getElementById("dark-mode-toggle").checked = true;
     }
 
     function toggleDarkMode() {

--- a/index.html
+++ b/index.html
@@ -16,10 +16,17 @@
     <meta name="msapplication-config" content="resources/favicon/browserconfig.xml">
     <meta name="theme-color" content="#364f6b">
     <title>Time It</title>
+    <script>
+        const theme = localStorage.getItem('theme');
+        if (theme === "dark") {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        }
+    </script>
 </head>
 
 <body>
     <div class="navbar">
+        <button id="theme-toggle" onclick="toggleDarkMode()"></button>
         <div class="navbar-logo">
             <h2>Time It</h2>
         </div>
@@ -150,5 +157,35 @@
         <!-- <div class="signature">Mais Hatem</div> -->
     </div>
 </body>
+<script>
+    const userPrefers = getComputedStyle(document.documentElement).getPropertyValue('content');
+
+    if (theme === "dark") {
+        document.getElementById("theme-toggle").innerHTML = "Light Mode";
+    } else if (theme === "light") {
+        document.getElementById("theme-toggle").innerHTML = "Dark Mode";
+    } else if  (userPrefers === "dark") {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        window.localStorage.setItem('theme', 'dark');
+        document.getElementById("theme-toggle").innerHTML = "Light Mode";
+    } else {
+        document.documentElement.setAttribute('data-theme', 'light');
+        window.localStorage.setItem('theme', 'light');
+        document.getElementById("theme-toggle").innerHTML = "Dark Mode";
+    }
+
+    function toggleDarkMode() {
+        let currentMode = document.documentElement.getAttribute('data-theme');
+        if (currentMode === "dark") {
+            document.documentElement.setAttribute('data-theme', 'light');
+            window.localStorage.setItem('theme', 'light');
+            document.getElementById("theme-toggle").innerHTML = "Dark Mode";
+        } else {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            window.localStorage.setItem('theme', 'dark');
+            document.getElementById("theme-toggle").innerHTML = "Light Mode";
+        }
+    }
+</script>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -180,11 +180,9 @@
     } else if (theme === "light") {
         document.documentElement.setAttribute("data-theme", "light");
     } else if  (userPrefers == "dark") {
-        console.log("in the dark prefer");
         document.documentElement.setAttribute("data-theme", "dark");
         window.localStorage.setItem("theme", "dark");
     } else {
-        console.log("in the light prefer");
         document.documentElement.setAttribute("data-theme", "light");
         window.localStorage.setItem("theme", "light");
     }

--- a/index.html
+++ b/index.html
@@ -27,20 +27,6 @@
 
 <body>
     <div class="navbar">
-        <div class="navbar-dark-mode-toggle">
-            <label>
-                <input class='toggle-checkbox' type='checkbox' onclick="toggleDarkMode()" id="dark-mode-toggle"></input>
-                <div class='toggle-slot'>
-                  <div class='sun-icon-wrapper'>
-                    <div class="iconify sun-icon" data-icon="feather-sun" data-inline="false"></div>
-                  </div>
-                  <div class='toggle-button'></div>
-                  <div class='moon-icon-wrapper'>
-                    <div class="iconify moon-icon" data-icon="feather-moon" data-inline="false"></div>
-                  </div>
-                </div>
-              </label>
-        </div>
         <div class="navbar-logo">
             <h2>Time It</h2>
         </div>
@@ -54,6 +40,20 @@
             <div class="btn">
                 <a target="#" href="https://github.com/time-it-app">contribute</a>
             </div>
+        </div>
+        <div class="navbar-dark-mode-toggle">
+            <label>
+                <input class='toggle-checkbox' type='checkbox' onclick="toggleDarkMode()" id="dark-mode-toggle"></input>
+                <div class='toggle-slot'>
+                  <div class='sun-icon-wrapper'>
+                    <div class="iconify sun-icon" data-icon="feather-sun" data-inline="false"></div>
+                  </div>
+                  <div class='toggle-button'></div>
+                  <div class='moon-icon-wrapper'>
+                    <div class="iconify moon-icon" data-icon="feather-moon" data-inline="false"></div>
+                  </div>
+                </div>
+              </label>
         </div>
     </div>
     <div class="hero">

--- a/index.html
+++ b/index.html
@@ -21,15 +21,6 @@
         if (theme === "dark") {
             document.documentElement.setAttribute('data-theme', 'dark');
         }
-
-        function onLoad() {
-            console.log("theme", theme);
-            if (!theme || theme === "light")
-                document.getElementById("dark-mode-toggle").checked = true;
-            else {
-                document.getElementById("dark-mode-toggle").checked = false;
-            }
-        }
     </script>
     <script src="https://code.iconify.design/1/1.0.4/iconify.min.js"></script>
 </head>
@@ -184,17 +175,15 @@
     const userPrefers = getComputedStyle(document.documentElement).getPropertyValue('content');
 
     if (theme === "dark") {
-        document.getElementById("dark-mode-toggle").checked = false;
+        document.documentElement.setAttribute('data-theme', 'dark');
     } else if (theme === "light") {
-        document.getElementById("dark-mode-toggle").checked = true;
+        document.documentElement.setAttribute('data-theme', 'light');
     } else if  (userPrefers === "dark") {
         document.documentElement.setAttribute('data-theme', 'dark');
         window.localStorage.setItem('theme', 'dark');
-        document.getElementById("dark-mode-toggle").checked = false;
     } else {
         document.documentElement.setAttribute('data-theme', 'light');
         window.localStorage.setItem('theme', 'light');
-        document.getElementById("dark-mode-toggle").checked = true;
     }
 
     function toggleDarkMode() {

--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
     <meta name="theme-color" content="#364f6b">
     <title>Time It</title>
     <script>
-        const theme = localStorage.getItem('theme');
+        const theme = localStorage.getItem("theme");
         if (theme === "dark") {
-            document.documentElement.setAttribute('data-theme', 'dark');
+            document.documentElement.setAttribute("data-theme", "dark");
         }
     </script>
     <script src="https://code.iconify.design/1/1.0.4/iconify.min.js"></script>
@@ -43,17 +43,17 @@
         </div>
         <div class="navbar-dark-mode-toggle">
             <label>
-                <input class='toggle-checkbox' type='checkbox' onclick="toggleDarkMode()" id="dark-mode-toggle"></input>
-                <div class='toggle-slot'>
-                  <div class='sun-icon-wrapper'>
-                    <div class="iconify sun-icon" data-icon="feather-sun" data-inline="false"></div>
-                  </div>
-                  <div class='toggle-button'></div>
-                  <div class='moon-icon-wrapper'>
-                    <div class="iconify moon-icon" data-icon="feather-moon" data-inline="false"></div>
-                  </div>
+                <input class="toggle-checkbox" type="checkbox" onclick="toggleDarkMode()" id="dark-mode-toggle"></input>
+                <div class="toggle-slot">
+                    <div class="sun-icon-wrapper">
+                        <div class="iconify sun-icon" data-icon="feather-sun" data-inline="false"></div>
+                    </div>
+                    <div class="toggle-button"></div>
+                    <div class="moon-icon-wrapper">
+                        <div class="iconify moon-icon" data-icon="feather-moon" data-inline="false"></div>
+                    </div>
                 </div>
-              </label>
+            </label>
         </div>
     </div>
     <div class="hero">
@@ -172,30 +172,31 @@
     </div>
 </body>
 <script>
-    const userPrefers = getComputedStyle(document.documentElement).getPropertyValue('content');
+    let userPrefers = getComputedStyle(document.documentElement).getPropertyValue("content");
+    userPrefers = userPrefers.replace(/["]+/g, '');
 
     if (theme === "dark") {
-        document.documentElement.setAttribute('data-theme', 'dark');
+        document.documentElement.setAttribute("data-theme", "dark");
     } else if (theme === "light") {
-        document.documentElement.setAttribute('data-theme', 'light');
-    } else if  (userPrefers === "dark") {
-        document.documentElement.setAttribute('data-theme', 'dark');
-        window.localStorage.setItem('theme', 'dark');
+        document.documentElement.setAttribute("data-theme", "light");
+    } else if  (userPrefers == "dark") {
+        console.log("in the dark prefer");
+        document.documentElement.setAttribute("data-theme", "dark");
+        window.localStorage.setItem("theme", "dark");
     } else {
-        document.documentElement.setAttribute('data-theme', 'light');
-        window.localStorage.setItem('theme', 'light');
+        console.log("in the light prefer");
+        document.documentElement.setAttribute("data-theme", "light");
+        window.localStorage.setItem("theme", "light");
     }
 
     function toggleDarkMode() {
-        let currentMode = document.documentElement.getAttribute('data-theme');
+        let currentMode = document.documentElement.getAttribute("data-theme");
         if (currentMode === "dark") {
-            document.documentElement.setAttribute('data-theme', 'light');
-            window.localStorage.setItem('theme', 'light');
-            document.getElementById("theme-toggle").innerHTML = "Dark Mode";
+            document.documentElement.setAttribute("data-theme", "light");
+            window.localStorage.setItem("theme", "light");
         } else {
-            document.documentElement.setAttribute('data-theme', 'dark');
-            window.localStorage.setItem('theme', 'dark');
-            document.getElementById("theme-toggle").innerHTML = "Light Mode";
+            document.documentElement.setAttribute("data-theme", "dark");
+            window.localStorage.setItem("theme", "dark");
         }
     }
 </script>

--- a/styles.css
+++ b/styles.css
@@ -29,12 +29,12 @@ html, html[data-theme="light"] {
   --main-text-color: hsl(0, 0%, 0%);
   --toggle-slot-bg: #374151;
   --toggle-button-bg: #485367;
-  --toggle-button-box-shadow: inset 0px 0px 0px 0.19em white;
-  --toggle-button-transform: translate(0.44em, 0.44em);
+  --toggle-button-box-shadow: inset 0px 0px 0px 12% white;
+  --toggle-button-transform: translate(27%, 27%);
   --moon-icon-wrapper-opacity: 1;
-  --moon-icon-wrapper-transform: translate(3em, 0.5em) rotate(-15deg);
+  --moon-icon-wrapper-transform: translate(200%, 33%) rotate(-15deg);
   --sun-icon-wrapper-opacity: 0;
-  --sun-icon-wrapper-transform: translate(0.75em, 0.5em) rotate(0deg);
+  --sun-icon-wrapper-transform: translate(50%, 33%) rotate(0deg);
 }
 
 html[data-theme="dark"] {
@@ -43,12 +43,12 @@ html[data-theme="dark"] {
   --main-text-color: hsl(0, 10%, 80%);
   --toggle-slot-bg: white;
   --toggle-button-bg: #ffeccf;
-  --toggle-button-box-shadow: inset 0px 0px 0px 0.19em #ffbb52;
-  --toggle-button-transform: translate(2.94em, 0.44em);
+  --toggle-button-box-shadow: inset 0px 0px 0px 3px #ffbb52;
+  --toggle-button-transform: translate(180%, 27%);
   --moon-icon-wrapper-opacity: 0;
-  --moon-icon-wrapper-transform: translate(2.75em, 0.5em) rotate(0deg);
+  --moon-icon-wrapper-transform: translate(184%, 33%) rotate(0deg);
   --sun-icon-wrapper-opacity: 1;
-  --sun-icon-wrapper-transform: translate(0.5em, 0.5em) rotate(15deg);
+  --sun-icon-wrapper-transform: translate(33%, 33%) rotate(15deg);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -68,20 +68,19 @@ html[data-theme="dark"] {
 
 .toggle-slot {
   position: relative;
-  height: 2.5em;
-  width: 5em;
+  height: 80%;
+  width: calc(8/9*100%);
   border: 5px solid #e4e7ec;
-  border-radius: 2.5em;
+  border-radius: 40px;
   background-color: var(--toggle-slot-bg);
-  box-shadow: 0px 10px 25px #e4e7ec;
   transition: background-color 250ms;
   cursor: pointer;
 }
 
 .toggle-button {
   position: absolute;
-  height: 1.625em;
-  width: 1.625em;
+  height: 65%;
+  width: 32.5%;
   border-radius: 50%;
   background-color: var(--toggle-button-bg);
   box-shadow: var(--toggle-button-box-shadow);
@@ -91,15 +90,15 @@ html[data-theme="dark"] {
 
 .sun-icon {
   position: absolute;
-  height: 1.5em;
-  width: 1.5em;
+  height: 100%;
+  width: 100%;
   color: #ffbb52;
 }
 
 .sun-icon-wrapper {
   position: absolute;
-  height: 1.5em;
-  width: 1.5em;
+  height: 60%;
+  width: 30%;
   opacity: var(--sun-icon-wrapper-opacity);
   transform: var(--sun-icon-wrapper-transform);
   transform-origin: 50% 50%;
@@ -108,15 +107,15 @@ html[data-theme="dark"] {
 
 .moon-icon {
   position: absolute;
-  height: 1.5em;
-  width: 1.5em;
+  height: 100%;
+  width: 100%;
   color: white;
 }
 
 .moon-icon-wrapper {
   position: absolute;
-  height: 1.5em;
-  width: 1.5em;
+  height: 60%;
+  width: 30%;
   opacity: var(--moon-icon-wrapper-opacity);
   transform: var(--moon-icon-wrapper-transform);
   transform-origin: 50% 50%;
@@ -146,6 +145,7 @@ body {
   flex-direction: column;
   padding-top: 20px;
   align-items: center;
+  position: relative;
 }
 
 .navbar-logo h2 {
@@ -189,6 +189,14 @@ body {
 
 .navbar-logo h2::selection {
   background: #364f6b;
+}
+
+.navbar-dark-mode-toggle {
+  position: absolute;
+  padding: 10px;
+  right: 0;
+  width: 90px;
+  height: 50px;
 }
 
 /* ================ Hero ================ */
@@ -464,6 +472,9 @@ body {
     margin: 0 10px;
     padding: 5px;
     font-size: large;
+  }
+  .navbar-dark-mode-toggle {
+    position: initial;
   }
   .hero {
     flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -1,13 +1,13 @@
 @import url("https://fonts.googleapis.com/css2?family=Bungee+Shade&family=Bungee&family=Dawning+of+a+New+Day&family=Jura:wght@300;400;500;600;700&family=Zilla+Slab:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=VT323&display=swap");
 
-/* 
+/*
 
-FONTS 
+FONTS
 
 font-family: 'Bungee Shade', cursive;
 font-family: 'Dawning of a New Day', cursive;
 font-family: 'Jura', sans-serif;
-font-family: 'VT323', monospace; 
+font-family: 'VT323', monospace;
 font-family: 'PrimaSans';
 font-family: 'Zilla Slab', serif;
 
@@ -16,12 +16,30 @@ add light mode toggle
 */
 
 /* add color variables */
-/* 
+/*
 #FC5185 pink
 #364F6B blue
 #3FC1C9 light blue
-#FCE38A yellow 
+#FCE38A yellow
 */
+
+html, html[data-theme="light"] {
+  --light-text-color: hsl(0, 0%, 35%);
+  --main-background-color: hsl(0, 5%, 95%);
+  --main-text-color: hsl(0, 0%, 0%);
+}
+
+html[data-theme="dark"] {
+  --light-text-color: hsl(0, 0%, 60%);
+  --main-background-color: hsl(0, 0%, 10%);
+  --main-text-color: hsl(0, 10%, 80%);
+}
+
+@media (prefers-color-scheme: dark) {
+  html {
+    content: "dark";
+  }
+}
 
 /* ================ Fonts and Colors ================ */
 
@@ -35,7 +53,7 @@ add light mode toggle
 /* ================ Body ================ */
 
 body {
-  background-color: #f4fafa;
+  background-color: var(--main-background-color);
   margin: 0;
 }
 
@@ -455,7 +473,7 @@ body {
     padding: 10px;
     text-align: center;
   }
- 
+
   .hero-illustration {
     padding: 10px;
     text-align: center;

--- a/styles.css
+++ b/styles.css
@@ -33,12 +33,98 @@ html[data-theme="dark"] {
   --light-text-color: hsl(0, 0%, 60%);
   --main-background-color: hsl(0, 0%, 10%);
   --main-text-color: hsl(0, 10%, 80%);
+
 }
 
 @media (prefers-color-scheme: dark) {
   html {
     content: "dark";
   }
+}
+
+/* ================ Dark Mode Toggle ================ */
+.toggle-checkbox {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+
+.toggle-slot {
+  position: relative;
+  height: 2.5em;
+  width: 5em;
+  border: 5px solid #e4e7ec;
+  border-radius: 2.5em;
+  background-color: white;
+  box-shadow: 0px 10px 25px #e4e7ec;
+  transition: background-color 250ms;
+}
+
+.toggle-checkbox:checked ~ .toggle-slot {
+  background-color: #374151;
+}
+
+.toggle-button {
+  transform: translate(2.94em, 0.44em);
+  position: absolute;
+  height: 1.625em;
+  width: 1.625em;
+  border-radius: 50%;
+  background-color: #ffeccf;
+  box-shadow: inset 0px 0px 0px 0.19em #ffbb52;
+  transition: background-color 250ms, border-color 250ms, transform 500ms cubic-bezier(.26,2,.46,.71);
+}
+
+.toggle-checkbox:checked ~ .toggle-slot .toggle-button {
+  background-color: #485367;
+  box-shadow: inset 0px 0px 0px 0.19em white;
+  transform: translate(0.44em, 0.44em);
+}
+
+.sun-icon {
+  position: absolute;
+  height: 1.5em;
+  width: 1.5em;
+  color: #ffbb52;
+}
+
+.sun-icon-wrapper {
+  position: absolute;
+  height: 1.5em;
+  width: 1.5em;
+  opacity: 1;
+  transform: translate(0.5em, 0.5em) rotate(15deg);
+  transform-origin: 50% 50%;
+  transition: opacity 150ms, transform 500ms cubic-bezier(.26,2,.46,.71);
+}
+
+.toggle-checkbox:checked ~ .toggle-slot .sun-icon-wrapper {
+  opacity: 0;
+  transform: translate(0.75em, 0.5em) rotate(0deg);
+}
+
+.moon-icon {
+  position: absolute;
+  height: 1.5em;
+  width: 1.5em;
+  color: white;
+}
+
+.moon-icon-wrapper {
+  position: absolute;
+  height: 1.5em;
+  width: 1.5em;
+  opacity: 0;
+  transform: translate(2.75em, 0.5em) rotate(0deg);
+  transform-origin: 50% 50%;
+  transition: opacity 150ms, transform 500ms cubic-bezier(.26,2.5,.46,.71);
+}
+
+.toggle-checkbox:checked ~ .toggle-slot .moon-icon-wrapper {
+  opacity: 1;
+  transform: translate(3em, 0.5em) rotate(-15deg);
 }
 
 /* ================ Fonts and Colors ================ */
@@ -107,6 +193,10 @@ body {
 
 .navbar-logo h2::selection {
   background: #364f6b;
+}
+
+.navbar-dark-mode-toggle {
+  /* height: 30px; */
 }
 
 /* ================ Hero ================ */

--- a/styles.css
+++ b/styles.css
@@ -1,60 +1,62 @@
 @import url("https://fonts.googleapis.com/css2?family=Bungee+Shade&family=Bungee&family=Dawning+of+a+New+Day&family=Jura:wght@300;400;500;600;700&family=Zilla+Slab:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&family=VT323&display=swap");
 
-/*
+/* 
 
-FONTS
+FONTS 
 
 font-family: 'Bungee Shade', cursive;
 font-family: 'Dawning of a New Day', cursive;
 font-family: 'Jura', sans-serif;
-font-family: 'VT323', monospace;
+font-family: 'VT323', monospace; 
 font-family: 'PrimaSans';
 font-family: 'Zilla Slab', serif;
 
 */
 
+
 /* add color variables */
 
-/*
+
+/* 
 #FC5185 pink
 #364F6B blue
 #3FC1C9 light blue
-#FCE38A yellow
+#FCE38A yellow 
 */
 
 /* ================ Theme Variables ================ */
 
 html,
 html[data-theme="light"] {
-  --main-background-color: hsl(0, 5%, 95%);
-  --main-text-color: #364f6b;
-  --toggle-slot-bg: #374151;
-  --toggle-button-bg: #485367;
-  --toggle-button-box-shadow: inset 0px 0px 0px 12% white;
-  --toggle-button-transform: translate(27%, 27%);
-  --moon-icon-wrapper-opacity: 1;
-  --moon-icon-wrapper-transform: translate(200%, 33%) rotate(-15deg);
-  --sun-icon-wrapper-opacity: 0;
-  --sun-icon-wrapper-transform: translate(50%, 33%) rotate(0deg);
+    --main-background-color: hsl(0, 5%, 95%);
+    --main-text-color: #364f6b;
+    --toggle-slot-bg: #374151;
+    --toggle-button-bg: #485367;
+    --toggle-button-box-shadow: inset 0px 0px 0px 12% white;
+    --toggle-button-transform: translate(27%, 27%);
+    --moon-icon-wrapper-opacity: 1;
+    --moon-icon-wrapper-transform: translate(200%, 33%) rotate(-15deg);
+    --sun-icon-wrapper-opacity: 0;
+    --sun-icon-wrapper-transform: translate(50%, 33%) rotate(0deg);
 }
 
 html[data-theme="dark"] {
-  --main-background-color: hsl(0, 0%, 10%);
-  --main-text-color: hsl(0, 10%, 80%);
-  --toggle-slot-bg: white;
-  --toggle-button-bg: #ffeccf;
-  --toggle-button-box-shadow: inset 0px 0px 0px 3px #ffbb52;
-  --toggle-button-transform: translate(180%, 27%);
-  --moon-icon-wrapper-opacity: 0;
-  --moon-icon-wrapper-transform: translate(184%, 33%) rotate(0deg);
-  --sun-icon-wrapper-opacity: 1;
-  --sun-icon-wrapper-transform: translate(33%, 33%) rotate(15deg);
+    --main-background-color: hsl(0, 0%, 10%);
+    --main-text-color: hsl(0, 10%, 80%);
+    --toggle-slot-bg: white;
+    --toggle-button-bg: #ffeccf;
+    --toggle-button-box-shadow: inset 0px 0px 0px 3px #ffbb52;
+    --toggle-button-transform: translate(180%, 27%);
+    --moon-icon-wrapper-opacity: 0;
+    --moon-icon-wrapper-transform: translate(184%, 33%) rotate(0deg);
+    --sun-icon-wrapper-opacity: 1;
+    --sun-icon-wrapper-transform: translate(33%, 33%) rotate(15deg);
 }
 
 @media (prefers-color-scheme: dark) {
-  html {
-    content: "dark";
-  }
+    html {
+        content: "dark";
+    }
 }
 
 /* ================ Dark Mode Toggle ================ */
@@ -127,499 +129,503 @@ html[data-theme="dark"] {
 /* ================ Fonts and Colors ================ */
 
 @font-face {
-  font-family: "PrimaSans";
-  src: url("resources/fonts/PrimaSansMonoBT-Roman.otf") format("truetype");
-  font-weight: normal;
-  font-style: normal;
+    font-family: "PrimaSans";
+    src: url("resources/fonts/PrimaSansMonoBT-Roman.otf") format("truetype");
+    font-weight: normal;
+    font-style: normal;
 }
+
 
 /* ================ Body ================ */
 
 body {
-  background-color: var(--main-background-color);
-  margin: 0;
-  transition: background-color 250ms;
+    background-color: var(--main-background-color);
+    margin: 0;
+    transition: background-color 250ms;
 }
+
 
 /* ================ Navbar ================ */
 
 .navbar {
-  display: flex;
-  flex-direction: column;
-  padding-top: 20px;
-  align-items: center;
-  position: relative;
+    display: flex;
+    flex-direction: column;
+    padding-top: 20px;
+    align-items: center;
 }
 
 .navbar-logo h2 {
-  font-family: "Bungee Shade", cursive;
-  color: #fc5185;
-  /*   -webkit-text-stroke-width: 2px; */
-  /*   -webkit-text-stroke-color: #fce38a; */
-  font-size: 80px;
-  margin: 0;
-  padding: 0;
+    font-family: "Bungee Shade", cursive;
+    color: #fc5185;
+    /*   -webkit-text-stroke-width: 2px; */
+    /*   -webkit-text-stroke-color: #fce38a; */
+    font-size: 80px;
+    margin: 0;
+    padding: 0;
 }
 
 .navbar-buttons {
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  padding: 20px;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    padding: 20px;
 }
 
 .btn {
-  height: 30px;
+    height: 30px;
 }
 
 .btn a {
-  font-family: "VT323", monospace;
-  font-size: x-large;
-  text-decoration: none;
-  margin: 0 20px;
-  padding: 10px;
-  background-color: #fc5185;
-  color: #fce38a;
-  box-shadow: -5px 5px #364f6b;
+    font-family: "VT323", monospace;
+    font-size: x-large;
+    text-decoration: none;
+    margin: 0 20px;
+    padding: 10px;
+    background-color: #fc5185;
+    color: #fce38a;
+    box-shadow: -5px 5px #364f6b;
 }
 
 .navbar-buttons .btn a:active {
-  box-shadow: unset;
-  display: block;
-  transform: translate(-5px, -5px);
+    box-shadow: unset;
+    display: block;
+    transform: translate(-5px, -5px);
 }
 
 .navbar-logo h2::selection {
-  background: #364f6b;
+    background: #364f6b;
 }
 
 .navbar-dark-mode-toggle {
-  position: absolute;
-  padding: 10px;
-  right: 0;
-  width: 68px;
-  height: 38px;
+    position: absolute;
+    padding: 10px;
+    right: 0;
+    width: 68px;
+    height: 38px;
 }
 
 /* ================ Hero ================ */
 
 .hero {
-  display: flex;
-  justify-content: space-between;
-  padding: 20px 20px 50px 20px;
-  font-family: "Zilla Slab", serif;
-  align-items: center;
+    display: flex;
+    justify-content: space-between;
+    padding: 20px 20px 50px 20px;
+    font-family: "Zilla Slab", serif;
+    align-items: center;
 }
 
 .hero-text {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  padding: 0 120px 0 70px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    padding: 0 120px 0 70px;
 }
 
 .hero-subheader {
-  color: var(--main-text-color);
-  font-size: 50px;
+    color: var(--main-text-color);
+    font-size: 50px;
 }
 
 .hero-header {
-  color: var(--main-text-color);
-  font-size: 52px;
-  font-weight: bolder;
+    color: var(--main-text-color);
+    font-size: 52px;
+    font-weight: bolder;
 }
 
 .hero-illustration img {
-  max-width: 620px;
+    max-width: 620px;
 }
 
 .hero-illustration {
-  padding: 35px 20px 20px 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+    padding: 35px 20px 20px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .hero-subheader::selection,
 .hero-header::selection {
-  background: #fce38a;
+    background: #fce38a;
 }
+
 
 /* ================ Features ================ */
 
 .features-listing {
-  padding: 45px 0 10px 0;
-  display: flex;
-  justify-content: center;
+    padding: 45px 0 10px 0;
+    display: flex;
+    justify-content: center;
 }
 
 .features-title {
-  font-family: "Zilla Slab", serif;
-  font-weight: 700;
-  font-size: 60px;
-  text-align: center;
+    font-family: "Zilla Slab", serif;
+    font-weight: 700;
+    font-size: 60px;
+    text-align: center;
 }
 
 .feature-title {
-  font-family: "Zilla Slab", serif;
-  font-weight: 700;
-  font-size: 40px;
+    font-family: "Zilla Slab", serif;
+    font-weight: 700;
+    font-size: 40px;
 }
 
 .feature-description {
-  font-family: "Zilla Slab", serif;
-  font-weight: 500;
-  text-align-last: center;
-  text-align: justify;
-  font-size: 20px;
-  padding: 0 25px;
+    font-family: "Zilla Slab", serif;
+    font-weight: 500;
+    text-align-last: center;
+    text-align: justify;
+    font-size: 20px;
+    padding: 0 25px;
 }
 
 .feature {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  padding: 20px;
-  transition: transform 250ms;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 20px;
+    transition: transform 250ms;
 }
 
 .feature:hover {
-  transform: translateY(-10px);
+    transform: translateY(-10px);
 }
 
 .features {
-  background-color: #364f6b;
-  color: #fce38a;
-  padding: 50px 0;
+    background-color: #364f6b;
+    color: #fce38a;
+    padding: 50px 0;
 }
 
 .feature-title::selection,
 .features-title::selection,
 .feature-description::selection {
-  background-color: #fc5185;
+    background-color: #fc5185;
 }
+
 
 /* ================ About / How it Works ================ */
 
 .about {
-  color: var(--main-text-color);
-  padding: 60px 80px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: center;
-  font-family: "Zilla Slab", serif;
+    color: var(--main-text-color);
+    padding: 60px 80px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+    font-family: "Zilla Slab", serif;
 }
 
 .about-title {
-  font-family: "Zilla Slab", serif;
-  font-weight: 700;
-  font-size: 60px;
+    font-family: "Zilla Slab", serif;
+    font-weight: 700;
+    font-size: 60px;
 }
 
 .about-description {
-  text-align-last: center;
-  text-align: justify;
-  font-weight: 500;
-  padding: 20px;
-  font-size: 20px;
+    text-align-last: center;
+    text-align: justify;
+    font-weight: 500;
+    padding: 20px;
+    font-size: 20px;
 }
 
-.about-description > div {
-  padding: 20px;
+.about-description>div {
+    padding: 20px;
 }
 
 .about-title::selection,
 .about-description::selection,
-.about-description > div::selection {
-  background: #fc5185;
-  color: #f4fafa;
+.about-description>div::selection {
+    background: #fc5185;
+    color: #f4fafa;
 }
+
 
 /* ================ Downloads ================ */
 
 .downloads-title {
-  font-family: "Zilla Slab", serif;
-  font-weight: 700;
-  font-size: 60px;
-  color: #fce38a;
+    font-family: "Zilla Slab", serif;
+    font-weight: 700;
+    font-size: 60px;
+    color: #fce38a;
 }
 
 .downloads {
-  background-color: #364f6b;
-  padding: 50px 200px;
-  align-items: center;
-  text-align: center;
+    background-color: #364f6b;
+    padding: 50px 200px;
+    align-items: center;
+    text-align: center;
 }
 
 .downloads-listings {
-  padding: 45px;
-  display: flex;
-  justify-content: space-between;
+    padding: 45px;
+    display: flex;
+    justify-content: space-between;
 }
 
 .download {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
 
 .download .btn a {
-  margin: 10px;
+    margin: 10px;
 }
 
 .download .btn a::selection {
-  background-color: #364f6b;
+    background-color: #364f6b;
 }
 
 .os-title {
-  color: #fce38a;
-  font-size: 30px;
-  font-family: "Zilla Slab", serif;
-  font-weight: 700;
-  margin-bottom: 20px;
+    color: #fce38a;
+    font-size: 30px;
+    font-family: "Zilla Slab", serif;
+    font-weight: 700;
+    margin-bottom: 20px;
 }
 
 .os-icon img {
-  max-width: 100px;
+    max-width: 100px;
 }
 
 .downloads-title::selection {
-  background-color: #fc5185;
+    background-color: #fc5185;
 }
 
 .small-font::selection {
-  background-color: #fc5185;
+    background-color: #fc5185;
 }
 
 .os-title::selection {
-  background-color: #fc5185;
+    background-color: #fc5185;
 }
 
 .small-font {
-  font-size: 30px;
-  font-family: "VT323", monospace;
+    font-size: 30px;
+    font-family: 'VT323', monospace;
 }
+
 
 /* ================ Footer ================ */
 
 .footer {
-  padding: 40px;
-  display: flex;
-  align-items: center;
-  flex-direction: column;
+    padding: 40px;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
 }
 
 .footer-logo {
-  font-family: "Bungee Shade", cursive;
-  color: var(--main-text-color);
-  -webkit-text-stroke-width: 1px;
-  font-size: 30px;
-  margin: 0;
-  padding: 0;
+    font-family: "Bungee Shade", cursive;
+    color: var(--main-text-color);
+    -webkit-text-stroke-width: 1px;
+    font-size: 30px;
+    margin: 0;
+    padding: 0;
 }
 
 .footer-description {
-  font-family: "Zilla Slab", serif;
-  margin: 20px 0;
-  font-weight: 500;
-  max-width: 700px;
-  text-align: center;
-  color: var(--main-text-color);
-  font-size: 15px;
-  text-align-last: center;
-  text-align: justify;
+    font-family: "Zilla Slab", serif;
+    margin: 20px 0;
+    font-weight: 500;
+    max-width: 700px;
+    text-align: center;
+    color: var(--main-text-color);
+    font-size: 15px;
+    text-align-last: center;
+    text-align: justify;
 }
 
 .footer-icons {
-  padding: 10px 0 0 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  width: 100px;
+    padding: 10px 0 0 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    width: 100px;
 }
 
 .signature {
-  font-family: "Dawning of a New Day", cursive;
-  color: var(--main-text-color);
-  font-size: 30px;
+    font-family: "Dawning of a New Day", cursive;
+    color: var(--main-text-color);
+    font-size: 30px;
 }
 
 .footer-logo::selection {
-  background: #fce38a;
+    background: #fce38a;
 }
 
 .footer-description::selection {
-  background: #fce38a;
+    background: #fce38a;
 }
 
+
 /* ================ Responsive Behavior ================ */
+
 
 /* Medium devices (desktops, 992px and up) */
 
 @media (max-width: 992px) {
     body,
-  html {
-    padding: 0;
-    margin: 0;
-  }
-  .navbar {
-    padding: 30px 10px;
-    flex-direction: column;
-    align-items: center;
-  }
-  .navbar-logo h2 {
-    font-size: 60px;
-    margin: 0;
-    padding: 0;
-  }
-  .navbar-buttons {
-    padding: 0;
-    margin-top: 10px;
-  }
-  .navbar-buttons .btn a {
-    margin: 0 10px;
-    padding: 5px;
-    font-size: large;
-  }
-  .navbar-dark-mode-toggle {
-    position: initial;
-  }
-  .hero {
-    flex-direction: column;
-    padding: 0;
-  }
-  .hero-text {
-    padding: 10px;
-    text-align: center;
-  }
-  .hero-subheader {
-    font-size: 36px;
-  }
-  .hero-header {
-    font-size: 33px;
-  }
-  .hero-illustration {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 20px 20px 20px 0;
-  }
-  .hero-illustration img {
-    max-width: 300px;
-  }
-  .features {
-    padding: 20px 5px;
-  }
-  .features-listing {
-    flex-direction: row;
-    padding: 0;
-  }
-  .features-title {
-    font-size: 50px;
-  }
-  .feature-title {
-    text-align: center;
-    font-size: 30px;
-  }
-  .about {
-    padding: 30px 10px;
-  }
-  .about-title {
-    font-size: 50px;
-  }
-  .about-description {
-    padding: 25px;
-  }
-  .downloads {
-    padding: 20px 5px;
-  }
-  .downloads-listings {
-    flex-direction: row;
-  }
-  .download {
-    margin-bottom: 20px;
-  }
+    html {
+        padding: 0;
+        margin: 0;
+    }
+    .navbar {
+        padding: 30px 10px;
+        flex-direction: column;
+        align-items: center;
+    }
+    .navbar-logo h2 {
+        font-size: 60px;
+        margin: 0;
+        padding: 0;
+    }
+    .navbar-buttons {
+        padding: 0;
+        margin-top: 10px;
+    }
+    .navbar-buttons .btn a {
+        margin: 0 10px;
+        padding: 5px;
+        font-size: large;
+    }
+    .hero {
+        flex-direction: column;
+        padding: 0;
+    }
+    .hero-text {
+        padding: 10px;
+        text-align: center;
+    }
+    .hero-subheader {
+        font-size: 36px;
+    }
+    .hero-header {
+        font-size: 33px;
+    }
+    .hero-illustration {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 20px 20px 20px 0;
+    }
+    .hero-illustration img {
+        max-width: 300px;
+    }
+    .features {
+        padding: 20px 5px;
+    }
+    .features-listing {
+        flex-direction: row;
+        padding: 0;
+    }
+    .features-title {
+        font-size: 50px;
+    }
+    .feature-title {
+        text-align: center;
+        font-size: 30px;
+    }
+    .about {
+        padding: 30px 10px;
+    }
+    .about-title {
+        font-size: 50px;
+    }
+    .about-description {
+        padding: 25px;
+    }
+    .downloads {
+        padding: 20px 5px;
+    }
+    .downloads-listings {
+        flex-direction: row;
+    }
+    .download {
+        margin-bottom: 20px;
+    }
 }
+
 
 /* Small devices (tablets, 768px and up) */
 
 @media (max-width: 768px) {
-  body,
-  html {
-    padding: 0;
-    margin: 0;
-  }
-  .navbar {
-    padding: 30px 10px;
-    flex-direction: column;
-    align-items: center;
-  }
-  .navbar-logo h2 {
-    font-size: 60px;
-    margin: 0;
-    padding: 0;
-  }
-  .navbar-buttons {
-    padding: 10px 0;
-  }
-  .navbar-buttons .btn a {
-    margin: 0 10px;
-    padding: 5px;
-    font-size: 25px;
-  }
-  .hero {
-    flex-direction: column;
-    padding: 0;
-  }
-  .hero-text {
-    padding: 10px;
-    text-align: center;
-  }
-
-  .hero-illustration {
-    padding: 10px;
-    text-align: center;
-  }
-  .hero-illustration img {
-    max-width: 300px;
-  }
-  .features {
-    padding: 20px 5px;
-  }
-  .features-listing {
-    flex-direction: column;
-    padding: 0;
-  }
-  .features-title {
-    font-size: 50px;
-  }
-  .feature-title {
-    text-align: center;
-    font-size: 30px;
-  }
-  .about {
-    padding: 30px 10px;
-  }
-  .about-title {
-    font-size: 50px;
-  }
-  .about-description {
-    padding: 25px;
-  }
-  .downloads {
-    padding: 20px 5px;
-  }
-  .downloads-listings {
-    flex-direction: column;
-  }
-  .download {
-    margin-bottom: 20px;
-  }
+    body,
+    html {
+        padding: 0;
+        margin: 0;
+    }
+    .navbar {
+        padding: 30px 10px;
+        flex-direction: column;
+        align-items: center;
+    }
+    .navbar-logo h2 {
+        font-size: 60px;
+        margin: 0;
+        padding: 0;
+    }
+    .navbar-buttons {
+        padding: 10px 0;
+    }
+    .navbar-buttons .btn a {
+        margin: 0 10px;
+        padding: 5px;
+        font-size: 25px;
+    }
+    .hero {
+        flex-direction: column;
+        padding: 0;
+    }
+    .hero-text {
+        padding: 10px;
+        text-align: center;
+    }
+    .hero-illustration {
+        padding: 10px;
+        text-align: center;
+    }
+    .hero-illustration img {
+        max-width: 300px;
+    }
+    .features {
+        padding: 20px 5px;
+    }
+    .features-listing {
+        flex-direction: column;
+        padding: 0;
+    }
+    .features-title {
+        font-size: 50px;
+    }
+    .feature-title {
+        text-align: center;
+        font-size: 30px;
+    }
+    .about {
+        padding: 30px 10px;
+    }
+    .about-title {
+        font-size: 50px;
+    }
+    .about-description {
+        padding: 25px;
+    }
+    .downloads {
+        padding: 20px 5px;
+    }
+    .downloads-listings {
+        flex-direction: column;
+    }
+    .download {
+        margin-bottom: 20px;
+    }
 }
+
 
 /* Large devices (large desktops, 1200px and up) */
 
-@media (min-width: 1200px) {
-}
+@media (min-width: 1200px) {}

--- a/styles.css
+++ b/styles.css
@@ -576,6 +576,9 @@ body {
         padding: 5px;
         font-size: 25px;
     }
+    .navbar-dark-mode-toggle {
+        position: initial;
+    }
     .hero {
         flex-direction: column;
         padding: 0;

--- a/styles.css
+++ b/styles.css
@@ -11,8 +11,6 @@ font-family: 'VT323', monospace;
 font-family: 'PrimaSans';
 font-family: 'Zilla Slab', serif;
 
-to-do:
-add light mode toggle
 */
 
 /* add color variables */
@@ -23,10 +21,11 @@ add light mode toggle
 #FCE38A yellow
 */
 
+/* ================ Theme Variables ================ */
+
 html, html[data-theme="light"] {
-  --light-text-color: hsl(0, 0%, 35%);
   --main-background-color: hsl(0, 5%, 95%);
-  --main-text-color: hsl(0, 0%, 0%);
+  --main-text-color: #364f6b;
   --toggle-slot-bg: #374151;
   --toggle-button-bg: #485367;
   --toggle-button-box-shadow: inset 0px 0px 0px 12% white;
@@ -38,7 +37,6 @@ html, html[data-theme="light"] {
 }
 
 html[data-theme="dark"] {
-  --light-text-color: hsl(0, 0%, 60%);
   --main-background-color: hsl(0, 0%, 10%);
   --main-text-color: hsl(0, 10%, 80%);
   --toggle-slot-bg: white;
@@ -58,6 +56,7 @@ html[data-theme="dark"] {
 }
 
 /* ================ Dark Mode Toggle ================ */
+
 .toggle-checkbox {
   position: absolute;
   opacity: 0;
@@ -136,6 +135,7 @@ html[data-theme="dark"] {
 body {
   background-color: var(--main-background-color);
   margin: 0;
+  transition: background-color 250ms;
 }
 
 /* ================ Navbar ================ */
@@ -195,8 +195,8 @@ body {
   position: absolute;
   padding: 10px;
   right: 0;
-  width: 90px;
-  height: 50px;
+  width: 68px;
+  height: 38px;
 }
 
 /* ================ Hero ================ */
@@ -217,12 +217,12 @@ body {
 }
 
 .hero-subheader {
-  color: #364f6b;
+  color: var(--main-text-color);
   font-size: 50px;
 }
 
 .hero-header {
-  color: #364f6b;
+  color: var(--main-text-color);
   font-size: 52px;
   font-weight: bolder;
 }
@@ -296,7 +296,7 @@ body {
 /* ================ About / How it Works ================ */
 
 .about {
-  color: #364f6b;
+  color: var(--main-text-color);
   padding: 60px 80px;
   display: flex;
   flex-direction: column;
@@ -404,7 +404,7 @@ body {
 
 .footer-logo {
   font-family: "Bungee Shade", cursive;
-  color: #364f6b;
+  color: var(--main-text-color);
   -webkit-text-stroke-width: 1px;
   font-size: 30px;
   margin: 0;
@@ -417,7 +417,7 @@ body {
   font-weight: 500;
   max-width: 700px;
   text-align: center;
-  color: #364f6b;
+  color: var(--main-text-color);
   font-size: 15px;
   text-align-last: center;
   text-align: justify;
@@ -433,7 +433,7 @@ body {
 
 .signature {
   font-family: "Dawning of a New Day", cursive;
-  color: #364f6b;
+  color: var(--main-text-color);
   font-size: 30px;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -27,13 +27,28 @@ html, html[data-theme="light"] {
   --light-text-color: hsl(0, 0%, 35%);
   --main-background-color: hsl(0, 5%, 95%);
   --main-text-color: hsl(0, 0%, 0%);
+  --toggle-slot-bg: #374151;
+  --toggle-button-bg: #485367;
+  --toggle-button-box-shadow: inset 0px 0px 0px 0.19em white;
+  --toggle-button-transform: translate(0.44em, 0.44em);
+  --moon-icon-wrapper-opacity: 1;
+  --moon-icon-wrapper-transform: translate(3em, 0.5em) rotate(-15deg);
+  --sun-icon-wrapper-opacity: 0;
+  --sun-icon-wrapper-transform: translate(0.75em, 0.5em) rotate(0deg);
 }
 
 html[data-theme="dark"] {
   --light-text-color: hsl(0, 0%, 60%);
   --main-background-color: hsl(0, 0%, 10%);
   --main-text-color: hsl(0, 10%, 80%);
-
+  --toggle-slot-bg: white;
+  --toggle-button-bg: #ffeccf;
+  --toggle-button-box-shadow: inset 0px 0px 0px 0.19em #ffbb52;
+  --toggle-button-transform: translate(2.94em, 0.44em);
+  --moon-icon-wrapper-opacity: 0;
+  --moon-icon-wrapper-transform: translate(2.75em, 0.5em) rotate(0deg);
+  --sun-icon-wrapper-opacity: 1;
+  --sun-icon-wrapper-transform: translate(0.5em, 0.5em) rotate(15deg);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -57,30 +72,21 @@ html[data-theme="dark"] {
   width: 5em;
   border: 5px solid #e4e7ec;
   border-radius: 2.5em;
-  background-color: white;
+  background-color: var(--toggle-slot-bg);
   box-shadow: 0px 10px 25px #e4e7ec;
   transition: background-color 250ms;
-}
-
-.toggle-checkbox:checked ~ .toggle-slot {
-  background-color: #374151;
+  cursor: pointer;
 }
 
 .toggle-button {
-  transform: translate(2.94em, 0.44em);
   position: absolute;
   height: 1.625em;
   width: 1.625em;
   border-radius: 50%;
-  background-color: #ffeccf;
-  box-shadow: inset 0px 0px 0px 0.19em #ffbb52;
+  background-color: var(--toggle-button-bg);
+  box-shadow: var(--toggle-button-box-shadow);
+  transform: var(--toggle-button-transform);
   transition: background-color 250ms, border-color 250ms, transform 500ms cubic-bezier(.26,2,.46,.71);
-}
-
-.toggle-checkbox:checked ~ .toggle-slot .toggle-button {
-  background-color: #485367;
-  box-shadow: inset 0px 0px 0px 0.19em white;
-  transform: translate(0.44em, 0.44em);
 }
 
 .sun-icon {
@@ -94,15 +100,10 @@ html[data-theme="dark"] {
   position: absolute;
   height: 1.5em;
   width: 1.5em;
-  opacity: 1;
-  transform: translate(0.5em, 0.5em) rotate(15deg);
+  opacity: var(--sun-icon-wrapper-opacity);
+  transform: var(--sun-icon-wrapper-transform);
   transform-origin: 50% 50%;
   transition: opacity 150ms, transform 500ms cubic-bezier(.26,2,.46,.71);
-}
-
-.toggle-checkbox:checked ~ .toggle-slot .sun-icon-wrapper {
-  opacity: 0;
-  transform: translate(0.75em, 0.5em) rotate(0deg);
 }
 
 .moon-icon {
@@ -116,15 +117,10 @@ html[data-theme="dark"] {
   position: absolute;
   height: 1.5em;
   width: 1.5em;
-  opacity: 0;
-  transform: translate(2.75em, 0.5em) rotate(0deg);
+  opacity: var(--moon-icon-wrapper-opacity);
+  transform: var(--moon-icon-wrapper-transform);
   transform-origin: 50% 50%;
   transition: opacity 150ms, transform 500ms cubic-bezier(.26,2.5,.46,.71);
-}
-
-.toggle-checkbox:checked ~ .toggle-slot .moon-icon-wrapper {
-  opacity: 1;
-  transform: translate(3em, 0.5em) rotate(-15deg);
 }
 
 /* ================ Fonts and Colors ================ */
@@ -193,10 +189,6 @@ body {
 
 .navbar-logo h2::selection {
   background: #364f6b;
-}
-
-.navbar-dark-mode-toggle {
-  /* height: 30px; */
 }
 
 /* ================ Hero ================ */


### PR DESCRIPTION
## What's in this PR?
This PR adds a dark mode to the site, as well as a toggle to the nav-bar to switch it on/off as per the request in Issue #2.  The users theme is saved in their browser for subsequent site visits.

## Changes made
- added a `data-theme` attribute to the `html`
- added toggle and accompanying CSS
- added dark/light theme variables for text, background and toggle states
- added scripts to the HTML that toggle the `data-theme` between `dark` and `light` on toggle click
- used the `prefers-color-scheme` media query to detect if the user has dark/light mode setup on their OS for first site visit

![Kapture 2021-10-16 at 18 21 59](https://user-images.githubusercontent.com/15695142/137605353-229410c9-e5e2-4571-ac15-a47d9fe11172.gif)